### PR TITLE
Clarify in `README.MD` that default profile is still required

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,20 @@ The dependencies to the [xflights](https://github.com/capire/xflights-java) appl
 You can also connect the `xtravels` application to a locally running [xflights](https://github.com/capire/xflights-java) application.
 
 Start the `xflights` application first, then start the `xtravels` application with the Spring Boot profiles `default` and `hybrid`.
+It is recommended to configure the Spring Profiles in your IDE. For VS Code you can add the following to your launch configurations:
 
-E.g. on the command line run:
+```json
+{
+  "type": "java",
+  "name": "xtravels (hybrid)",
+  "request": "launch",
+  "mainClass": "sap.capire.xtravels.Application",
+  "vmArgs": "-Dspring.profiles.active=default,hybrid"
+}
+```
+
+Alternatively start the application on the command line by executing:
+
 ```sh
 mvn spring-boot:run -Dspring-boot.run.profiles=default,hybrid
 ```

--- a/README.md
+++ b/README.md
@@ -95,7 +95,12 @@ The dependencies to the [xflights](https://github.com/capire/xflights-java) appl
 
 You can also connect the `xtravels` application to a locally running [xflights](https://github.com/capire/xflights-java) application.
 
-Start the `xflights` application first, then start the `xtravels` application with Spring Boot profile `hybrid`.
+Start the `xflights` application first, then start the `xtravels` application with the Spring Boot profiles `default` and `hybrid`.
+
+E.g. on the command line run:
+```sh
+mvn spring-boot:run -Dspring-boot.run.profiles=default,hybrid
+```
 
 ## License
 


### PR DESCRIPTION
Starting the app with the Spring Boot profile `hybrid` is not enough, the `default` profile is required, too.
 
Starting with `hybrid` profile only, results in an error `Table "SAP_CAPIRE_TRAVELS_BOOKINGS" not found`.

### Stracktrace
```txt
2025-10-21T11:27:59.768+02:00  INFO 37784 --- [  restartedMain] sap.capire.xtravels.Application          : Starting Application using Java 21.0.4 with PID 37784 (/Users/i541520/Coding/projects/capire/xtravels-java/srv/target/classes started by i541520 in /Users/i541520/Coding/projects/capire/xtravels-java/srv)
2025-10-21T11:27:59.769+02:00  INFO 37784 --- [  restartedMain] sap.capire.xtravels.Application          : The following 1 profile is active: "hybrid"
2025-10-21T11:27:59.787+02:00  INFO 37784 --- [  restartedMain] .e.DevToolsPropertyDefaultsPostProcessor : Devtools property defaults active! Set 'spring.devtools.add-properties' to 'false' to disable
2025-10-21T11:27:59.787+02:00  INFO 37784 --- [  restartedMain] .e.DevToolsPropertyDefaultsPostProcessor : For additional web related logging consider setting the 'logging.level.web' property to 'DEBUG'
2025-10-21T11:28:00.088+02:00  INFO 37784 --- [  restartedMain] c.s.c.services.impl.utils.CdsModelUtils  : Loaded CDS model from CSN resource path 'edmx/csn.json'
2025-10-21T11:28:00.103+02:00  INFO 37784 --- [  restartedMain] c.s.c.services.impl.ServiceCatalogImpl   : Registered service DefaultOutboxOrdered
2025-10-21T11:28:00.104+02:00  INFO 37784 --- [  restartedMain] c.s.c.services.impl.ServiceCatalogImpl   : Registered service DefaultOutboxUnordered
2025-10-21T11:28:00.104+02:00  INFO 37784 --- [  restartedMain] c.s.c.services.impl.ServiceCatalogImpl   : Registered service OutboxService$InMemory
2025-10-21T11:28:00.105+02:00  INFO 37784 --- [  restartedMain] c.s.c.services.impl.ServiceCatalogImpl   : Registered service ApplicationLifecycleService$Default
2025-10-21T11:28:00.105+02:00  INFO 37784 --- [  restartedMain] c.s.c.services.impl.ServiceCatalogImpl   : Registered service AuthorizationService$Default
2025-10-21T11:28:00.110+02:00  INFO 37784 --- [  restartedMain] c.s.c.services.impl.ServiceCatalogImpl   : Registered service xflights
2025-10-21T11:28:00.110+02:00  INFO 37784 --- [  restartedMain] c.s.c.services.impl.ServiceCatalogImpl   : Registered service TenantProviderService$Default
2025-10-21T11:28:00.111+02:00  INFO 37784 --- [  restartedMain] c.s.c.services.impl.ServiceCatalogImpl   : Registered service DeploymentService$Default
2025-10-21T11:28:00.112+02:00  INFO 37784 --- [  restartedMain] c.s.c.services.impl.ServiceCatalogImpl   : Registered service AuditLogService$Default
2025-10-21T11:28:00.117+02:00  INFO 37784 --- [  restartedMain] c.s.c.services.impl.ServiceCatalogImpl   : Registered service TravelService
2025-10-21T11:28:00.430+02:00  INFO 37784 --- [  restartedMain] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat initialized with port 8080 (http)
2025-10-21T11:28:00.436+02:00  INFO 37784 --- [  restartedMain] o.apache.catalina.core.StandardService   : Starting service [Tomcat]
2025-10-21T11:28:00.436+02:00  INFO 37784 --- [  restartedMain] o.apache.catalina.core.StandardEngine    : Starting Servlet engine: [Apache Tomcat/10.1.46]
2025-10-21T11:28:00.453+02:00  INFO 37784 --- [  restartedMain] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring embedded WebApplicationContext
2025-10-21T11:28:00.454+02:00  INFO 37784 --- [  restartedMain] w.s.c.ServletWebServerApplicationContext : Root WebApplicationContext: initialization completed in 666 ms
2025-10-21T11:28:00.500+02:00  INFO 37784 --- [  restartedMain] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Starting...
2025-10-21T11:28:00.575+02:00  INFO 37784 --- [  restartedMain] com.zaxxer.hikari.pool.HikariPool        : HikariPool-1 - Added connection conn0: url=jdbc:h2:mem:581ee452-7ba8-4762-b343-ab2a98817e8c user=SA
2025-10-21T11:28:00.575+02:00  INFO 37784 --- [  restartedMain] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Start completed.
2025-10-21T11:28:00.585+02:00  INFO 37784 --- [  restartedMain] c.s.c.services.impl.ServiceCatalogImpl   : Registered service PersistenceService$Default
2025-10-21T11:28:00.596+02:00  INFO 37784 --- [  restartedMain] c.s.c.f.s.c.adapter.AdapterBeanFactory   : Servlet CdsODataV4Servlet mapped to /odata/v4
2025-10-21T11:28:00.599+02:00  INFO 37784 --- [  restartedMain] c.s.c.f.s.c.adapter.AdapterBeanFactory   : Servlet IndexPageServlet mapped to /
2025-10-21T11:28:00.600+02:00  INFO 37784 --- [  restartedMain] c.s.c.f.s.c.adapter.AdapterBeanFactory   : Servlet CdsFioriPreviewServlet mapped to /$fiori-preview
2025-10-21T11:28:00.707+02:00  WARN 37784 --- [  restartedMain] .s.s.UserDetailsServiceAutoConfiguration :

Using generated security password: 1f9e50e5-a3a1-44c6-86e5-29c95f75df30

This generated password is for development use only. Your security configuration must be updated before running your application in production.

2025-10-21T11:28:00.709+02:00  INFO 37784 --- [  restartedMain] r$InitializeUserDetailsManagerConfigurer : Global AuthenticationManager configured with UserDetailsService bean with name inMemoryUserDetailsManager
2025-10-21T11:28:00.747+02:00  INFO 37784 --- [  restartedMain] c.s.c.f.s.c.a.m.MockUsersSecurityConfig  : Added mock user {"name":"privileged","password":"","systemUser":false,"privileged":true,"internalUser":false,"roles":[],"attributes":{},"additional":{},"valid":true}
2025-10-21T11:28:00.747+02:00  INFO 37784 --- [  restartedMain] c.s.c.f.s.c.a.m.MockUsersSecurityConfig  : Added mock user {"name":"authenticated","password":"","systemUser":false,"privileged":false,"internalUser":false,"roles":[],"attributes":{},"additional":{},"valid":true}
2025-10-21T11:28:00.747+02:00  INFO 37784 --- [  restartedMain] c.s.c.f.s.c.a.m.MockUsersSecurityConfig  : Added mock user {"name":"admin","password":"","systemUser":false,"privileged":false,"internalUser":false,"roles":["admin"],"attributes":{},"additional":{},"valid":true}
2025-10-21T11:28:00.747+02:00  INFO 37784 --- [  restartedMain] c.s.c.f.s.c.a.m.MockUsersSecurityConfig  : Added mock user {"name":"internal","password":"","systemUser":false,"privileged":false,"internalUser":true,"roles":[],"attributes":{},"additional":{},"valid":true}
2025-10-21T11:28:00.747+02:00  INFO 37784 --- [  restartedMain] c.s.c.f.s.c.a.m.MockUsersSecurityConfig  : Added mock user {"name":"system","password":"","systemUser":true,"privileged":false,"internalUser":false,"roles":[],"attributes":{},"additional":{},"valid":true}
2025-10-21T11:28:00.748+02:00  INFO 37784 --- [  restartedMain] c.s.c.f.s.c.a.m.MockUsersSecurityConfig  : *************************************************************************
2025-10-21T11:28:00.748+02:00  INFO 37784 --- [  restartedMain] c.s.c.f.s.c.a.m.MockUsersSecurityConfig  : *  Security configuration based on mock users found in active profile.  *
2025-10-21T11:28:00.748+02:00  INFO 37784 --- [  restartedMain] c.s.c.f.s.c.a.m.MockUsersSecurityConfig  : *                 !!! NEVER USE IN PRODUCTIVE MODE !!!                  *
2025-10-21T11:28:00.748+02:00  INFO 37784 --- [  restartedMain] c.s.c.f.s.c.a.m.MockUsersSecurityConfig  : *************************************************************************
2025-10-21T11:28:00.796+02:00  INFO 37784 --- [  restartedMain] c.s.c.s.impl.runtime.CdsRuntimeImpl      : Registered handler class sap.capire.xtravels.handler.CreationHandler
2025-10-21T11:28:00.796+02:00  INFO 37784 --- [  restartedMain] c.s.c.s.impl.runtime.CdsRuntimeImpl      : Registered handler class sap.capire.xtravels.handler.DeductDiscountHandler
2025-10-21T11:28:00.796+02:00  INFO 37784 --- [  restartedMain] c.s.c.s.impl.runtime.CdsRuntimeImpl      : Registered handler class sap.capire.xtravels.handler.FederationHandler
2025-10-21T11:28:00.797+02:00  INFO 37784 --- [  restartedMain] c.s.c.s.impl.runtime.CdsRuntimeImpl      : Registered handler class sap.capire.xtravels.handler.RecalculatePriceHandler
2025-10-21T11:28:00.797+02:00  INFO 37784 --- [  restartedMain] c.s.c.s.impl.runtime.CdsRuntimeImpl      : Registered handler class sap.capire.xtravels.handler.Workarounds
2025-10-21T11:28:00.806+02:00  INFO 37784 --- [  restartedMain] .s.c.a.o.v.m.p.EdmxProviderConfiguration : Initialized Default EDMX V4 Provider
2025-10-21T11:28:00.810+02:00  INFO 37784 --- [  restartedMain] .s.c.a.o.v.m.p.EdmxProviderConfiguration : Initialized Default EDMX I18n Provider
2025-10-21T11:28:00.837+02:00  INFO 37784 --- [  restartedMain] c.sap.cds.services.impl.utils.BuildInfo  : git.commit.id: aea9ce40b8bfe97d3a92da819a13caeb94cbd478
2025-10-21T11:28:00.838+02:00  INFO 37784 --- [  restartedMain] c.sap.cds.services.impl.utils.BuildInfo  : maven.version: 4.4.1
2025-10-21T11:28:00.880+02:00  INFO 37784 --- [  restartedMain] c.s.c.s.impl.runtime.CdsRuntimeImpl      : Exception marked the ChangeSet 3 as cancelled: Error executing the statement (service 'PersistenceService$Default', event 'CREATE', entity 'sap.capire.travels.TravelStatus')
2025-10-21T11:28:00.883+02:00  INFO 37784 --- [  restartedMain] c.s.c.s.impl.runtime.CdsRuntimeImpl      : Exception marked the ChangeSet 4 as cancelled: Error executing the statement (service 'PersistenceService$Default', event 'CREATE', entity 'sap.capire.travels.TravelStatus.texts')
2025-10-21T11:28:00.889+02:00  INFO 37784 --- [  restartedMain] c.s.c.s.impl.runtime.CdsRuntimeImpl      : Exception marked the ChangeSet 5 as cancelled: Error executing the statement (service 'PersistenceService$Default', event 'CREATE', entity 'sap.capire.travels.TravelAgencies')
2025-10-21T11:28:01.052+02:00  INFO 37784 --- [  restartedMain] c.s.c.s.impl.runtime.CdsRuntimeImpl      : Exception marked the ChangeSet 6 as cancelled: Error executing the statement (service 'PersistenceService$Default', event 'CREATE', entity 'sap.capire.travels.Bookings.Supplements')
2025-10-21T11:28:01.071+02:00  INFO 37784 --- [  restartedMain] c.s.c.s.impl.runtime.CdsRuntimeImpl      : Exception marked the ChangeSet 7 as cancelled: Error executing the statement (service 'PersistenceService$Default', event 'CREATE', entity 'sap.capire.travels.Passengers')
2025-10-21T11:28:01.162+02:00  INFO 37784 --- [  restartedMain] c.s.c.s.impl.runtime.CdsRuntimeImpl      : Exception marked the ChangeSet 8 as cancelled: Error executing the statement (service 'PersistenceService$Default', event 'CREATE', entity 'sap.capire.travels.Travels')
2025-10-21T11:28:01.230+02:00  INFO 37784 --- [  restartedMain] c.s.c.s.impl.runtime.CdsRuntimeImpl      : Exception marked the ChangeSet 9 as cancelled: Error executing the statement (service 'PersistenceService$Default', event 'CREATE', entity 'sap.capire.travels.Bookings')
2025-10-21T11:28:01.232+02:00  INFO 37784 --- [  restartedMain] c.s.c.s.impl.runtime.CdsRuntimeImpl      : Exception marked the ChangeSet 10 as cancelled: Error executing the statement (service 'PersistenceService$Default', event 'CREATE', entity 'sap.common.Countries.texts')
2025-10-21T11:28:01.234+02:00  INFO 37784 --- [  restartedMain] c.s.c.s.impl.runtime.CdsRuntimeImpl      : Exception marked the ChangeSet 11 as cancelled: Error executing the statement (service 'PersistenceService$Default', event 'CREATE', entity 'sap.common.Countries')
2025-10-21T11:28:01.235+02:00  INFO 37784 --- [  restartedMain] c.s.c.s.impl.runtime.CdsRuntimeImpl      : Exception marked the ChangeSet 12 as cancelled: Error executing the statement (service 'PersistenceService$Default', event 'CREATE', entity 'sap.common.Currencies.texts')
2025-10-21T11:28:01.236+02:00  INFO 37784 --- [  restartedMain] c.s.c.s.impl.runtime.CdsRuntimeImpl      : Exception marked the ChangeSet 13 as cancelled: Error executing the statement (service 'PersistenceService$Default', event 'CREATE', entity 'sap.common.Languages')
2025-10-21T11:28:01.237+02:00  INFO 37784 --- [  restartedMain] c.s.c.s.impl.runtime.CdsRuntimeImpl      : Exception marked the ChangeSet 14 as cancelled: Error executing the statement (service 'PersistenceService$Default', event 'CREATE', entity 'sap.common.Languages.texts')
2025-10-21T11:28:01.238+02:00  INFO 37784 --- [  restartedMain] c.s.c.s.impl.runtime.CdsRuntimeImpl      : Exception marked the ChangeSet 15 as cancelled: Error executing the statement (service 'PersistenceService$Default', event 'CREATE', entity 'sap.common.Currencies')
2025-10-21T11:28:01.240+02:00  INFO 37784 --- [  restartedMain] s.c.xtravels.handler.FederationHandler   : Performing initial load for Flights
2025-10-21T11:28:01.258+02:00  INFO 37784 --- [  restartedMain] c.s.c.s.impl.runtime.CdsRuntimeImpl      : Exception marked the ChangeSet 2 as cancelled: Error executing the statement (service 'PersistenceService$Default', event 'READ', entity 'sap.capire.travels.Bookings')
2025-10-21T11:28:01.259+02:00  WARN 37784 --- [  restartedMain] ConfigServletWebServerApplicationContext : Exception encountered during context initialization - cancelling refresh attempt: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'com.sap.cds.framework.spring.config.runtime.CdsRuntimeInitializer': Error executing the statement (service 'PersistenceService$Default', event 'READ', entity 'sap.capire.travels.Bookings')
2025-10-21T11:28:01.259+02:00  INFO 37784 --- [  restartedMain] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Shutdown initiated...
2025-10-21T11:28:01.260+02:00  INFO 37784 --- [  restartedMain] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Shutdown completed.
2025-10-21T11:28:01.261+02:00  INFO 37784 --- [  restartedMain] o.apache.catalina.core.StandardService   : Stopping service [Tomcat]
2025-10-21T11:28:01.265+02:00  INFO 37784 --- [  restartedMain] .s.b.a.l.ConditionEvaluationReportLogger :

Error starting ApplicationContext. To display the condition evaluation report re-run your application with 'debug' enabled.
2025-10-21T11:28:01.272+02:00 ERROR 37784 --- [  restartedMain] o.s.boot.SpringApplication               : Application run failed

org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'com.sap.cds.framework.spring.config.runtime.CdsRuntimeInitializer': Error executing the statement (service 'PersistenceService$Default', event 'READ', entity 'sap.capire.travels.Bookings')
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1826) ~[spring-beans-6.2.11.jar:6.2.11]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:607) ~[spring-beans-6.2.11.jar:6.2.11]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:529) ~[spring-beans-6.2.11.jar:6.2.11]
	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:339) ~[spring-beans-6.2.11.jar:6.2.11]
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:373) ~[spring-beans-6.2.11.jar:6.2.11]
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:337) ~[spring-beans-6.2.11.jar:6.2.11]
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:202) ~[spring-beans-6.2.11.jar:6.2.11]
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.instantiateSingleton(DefaultListableBeanFactory.java:1221) ~[spring-beans-6.2.11.jar:6.2.11]
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingleton(DefaultListableBeanFactory.java:1187) ~[spring-beans-6.2.11.jar:6.2.11]
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:1123) ~[spring-beans-6.2.11.jar:6.2.11]
	at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:987) ~[spring-context-6.2.11.jar:6.2.11]
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:627) ~[spring-context-6.2.11.jar:6.2.11]
	at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:146) ~[spring-boot-3.5.6.jar:3.5.6]
	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:752) ~[spring-boot-3.5.6.jar:3.5.6]
	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:439) ~[spring-boot-3.5.6.jar:3.5.6]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:318) ~[spring-boot-3.5.6.jar:3.5.6]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1361) ~[spring-boot-3.5.6.jar:3.5.6]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1350) ~[spring-boot-3.5.6.jar:3.5.6]
	at sap.capire.xtravels.Application.main(Application.java:10) ~[classes/:na]
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[na:na]
	at java.base/java.lang.reflect.Method.invoke(Method.java:580) ~[na:na]
	at org.springframework.boot.devtools.restart.RestartLauncher.run(RestartLauncher.java:50) ~[spring-boot-devtools-3.5.6.jar:3.5.6]
Caused by: com.sap.cds.services.impl.ContextualizedServiceException: Error executing the statement (service 'PersistenceService$Default', event 'READ', entity 'sap.capire.travels.Bookings')
	at com.sap.cds.services.impl.ServiceImpl.dispatch(ServiceImpl.java:269) ~[cds-services-impl-4.4.1.jar:na]
	at com.sap.cds.services.impl.ServiceImpl.emit(ServiceImpl.java:180) ~[cds-services-impl-4.4.1.jar:na]
	at com.sap.cds.services.ServiceDelegator.emit(ServiceDelegator.java:33) ~[cds-services-api-4.4.1.jar:na]
	at com.sap.cds.services.utils.services.AbstractCqnService.run(AbstractCqnService.java:64) ~[cds-services-utils-4.4.1.jar:na]
	at com.sap.cds.services.utils.services.AbstractCqnService.run(AbstractCqnService.java:48) ~[cds-services-utils-4.4.1.jar:na]
	at com.sap.cds.services.utils.services.AbstractCqnService.run(AbstractCqnService.java:54) ~[cds-services-utils-4.4.1.jar:na]
	at sap.capire.xtravels.handler.FederationHandler.initialLoad(FederationHandler.java:77) ~[classes/:na]
	at com.sap.cds.services.impl.handlerregistry.HandlerRegistryTools$DescribedHandler.process(HandlerRegistryTools.java:174) ~[cds-services-impl-4.4.1.jar:na]
	at com.sap.cds.services.impl.ServiceImpl.lambda$createOnHandlerChain$4(ServiceImpl.java:282) ~[cds-services-impl-4.4.1.jar:na]
	at com.sap.cds.services.impl.ServiceImpl.dispatch(ServiceImpl.java:249) ~[cds-services-impl-4.4.1.jar:na]
	at com.sap.cds.services.impl.ServiceImpl.lambda$dispatchInChangeSetContext$2(ServiceImpl.java:213) ~[cds-services-impl-4.4.1.jar:na]
	at com.sap.cds.services.impl.runtime.ChangeSetContextRunnerImpl.lambda$run$1(ChangeSetContextRunnerImpl.java:62) ~[cds-services-impl-4.4.1.jar:na]
	at com.sap.cds.services.impl.runtime.ChangeSetContextRunnerImpl.open(ChangeSetContextRunnerImpl.java:77) ~[cds-services-impl-4.4.1.jar:na]
	at com.sap.cds.services.impl.runtime.ChangeSetContextRunnerImpl.run(ChangeSetContextRunnerImpl.java:55) ~[cds-services-impl-4.4.1.jar:na]
	at com.sap.cds.services.impl.runtime.ChangeSetContextRunnerImpl.run(ChangeSetContextRunnerImpl.java:60) ~[cds-services-impl-4.4.1.jar:na]
	at com.sap.cds.services.impl.ServiceImpl.dispatchInChangeSetContext(ServiceImpl.java:213) ~[cds-services-impl-4.4.1.jar:na]
	at com.sap.cds.services.impl.ServiceImpl.emit(ServiceImpl.java:193) ~[cds-services-impl-4.4.1.jar:na]
	at com.sap.cds.services.ServiceDelegator.emit(ServiceDelegator.java:33) ~[cds-services-api-4.4.1.jar:na]
	at com.sap.cds.services.impl.application.ApplicationLifecycleServiceImpl.applicationPrepared(ApplicationLifecycleServiceImpl.java:37) ~[cds-services-impl-4.4.1.jar:na]
	at com.sap.cds.framework.spring.config.runtime.CdsRuntimeInitializer.lambda$afterPropertiesSet$6(CdsRuntimeInitializer.java:98) ~[cds-framework-spring-boot-4.4.1.jar:na]
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:184) ~[na:na]
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197) ~[na:na]
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179) ~[na:na]
	at java.base/java.util.concurrent.ConcurrentHashMap$ValueSpliterator.forEachRemaining(ConcurrentHashMap.java:3612) ~[na:na]
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[na:na]
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[na:na]
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151) ~[na:na]
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174) ~[na:na]
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[na:na]
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596) ~[na:na]
	at com.sap.cds.framework.spring.config.runtime.CdsRuntimeInitializer.lambda$afterPropertiesSet$7(CdsRuntimeInitializer.java:98) ~[cds-framework-spring-boot-4.4.1.jar:na]
	at com.sap.cds.services.impl.runtime.RequestContextRunnerImpl.lambda$run$3(RequestContextRunnerImpl.java:216) ~[cds-services-impl-4.4.1.jar:na]
	at com.sap.cds.services.impl.runtime.RequestContextRunnerImpl.run(RequestContextRunnerImpl.java:286) ~[cds-services-impl-4.4.1.jar:na]
	at com.sap.cds.services.impl.runtime.RequestContextRunnerImpl.run(RequestContextRunnerImpl.java:214) ~[cds-services-impl-4.4.1.jar:na]
	at com.sap.cds.framework.spring.config.runtime.CdsRuntimeInitializer.afterPropertiesSet(CdsRuntimeInitializer.java:94) ~[cds-framework-spring-boot-4.4.1.jar:na]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1873) ~[spring-beans-6.2.11.jar:6.2.11]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1822) ~[spring-beans-6.2.11.jar:6.2.11]
	... 21 common frames omitted
Caused by: com.sap.cds.CdsDataStoreException: Error executing the statement
	at com.sap.cds.impl.ExceptionHandler.dataStoreException(ExceptionHandler.java:62) ~[cds4j-runtime-4.4.1.jar:na]
	at com.sap.cds.impl.JDBCClient.executeQuery(JDBCClient.java:221) ~[cds4j-runtime-4.4.1.jar:na]
	at com.sap.cds.impl.CdsDataStoreImpl.executeResolvedQuery(CdsDataStoreImpl.java:222) ~[cds4j-runtime-4.4.1.jar:na]
	at com.sap.cds.impl.CdsDataStoreImpl.execute(CdsDataStoreImpl.java:205) ~[cds4j-runtime-4.4.1.jar:na]
	at com.sap.cds.impl.CdsDataStoreImpl.resolveAndExecuteQuery(CdsDataStoreImpl.java:169) ~[cds4j-runtime-4.4.1.jar:na]
	at com.sap.cds.impl.CdsDataStoreImpl.lambda$execute$0(CdsDataStoreImpl.java:146) ~[cds4j-runtime-4.4.1.jar:na]
	at com.sap.cds.impl.CqnLogger.runTimed(CqnLogger.java:63) ~[cds4j-core-4.4.1.jar:na]
	at com.sap.cds.impl.CqnLogger.runTimedCqn(CqnLogger.java:82) ~[cds4j-core-4.4.1.jar:na]
	at com.sap.cds.impl.CdsDataStoreImpl.execute(CdsDataStoreImpl.java:146) ~[cds4j-runtime-4.4.1.jar:na]
	at com.sap.cds.services.impl.persistence.JdbcPersistenceService.lambda$defaultRead$1(JdbcPersistenceService.java:152) ~[cds-feature-jdbc-4.4.1.jar:na]
	at com.sap.cds.services.impl.persistence.JdbcPersistenceService.checkExceptionAndOtelSpan(JdbcPersistenceService.java:231) ~[cds-feature-jdbc-4.4.1.jar:na]
	at com.sap.cds.services.impl.persistence.JdbcPersistenceService.defaultRead(JdbcPersistenceService.java:151) ~[cds-feature-jdbc-4.4.1.jar:na]
	at com.sap.cds.services.impl.handlerregistry.HandlerRegistryTools$DescribedHandler.process(HandlerRegistryTools.java:174) ~[cds-services-impl-4.4.1.jar:na]
	at com.sap.cds.services.impl.ServiceImpl.lambda$createOnHandlerChain$4(ServiceImpl.java:282) ~[cds-services-impl-4.4.1.jar:na]
	at com.sap.cds.services.impl.ServiceImpl.dispatch(ServiceImpl.java:249) ~[cds-services-impl-4.4.1.jar:na]
	... 57 common frames omitted
Caused by: com.sap.cds.CdsDataStoreException: SQL: SELECT DISTINCT T0."FLIGHT_ID" as "ID", T0."FLIGHT_DATE" as "date" FROM "SAP_CAPIRE_TRAVELS_BOOKINGS" T0
	... 72 common frames omitted
Caused by: org.h2.jdbc.JdbcSQLSyntaxErrorException: Tabelle "SAP_CAPIRE_TRAVELS_BOOKINGS" nicht gefunden (diese Datenbank ist leer)
Table "SAP_CAPIRE_TRAVELS_BOOKINGS" not found (this database is empty); SQL statement:
SELECT DISTINCT T0."FLIGHT_ID" as "ID", T0."FLIGHT_DATE" as "date" FROM "SAP_CAPIRE_TRAVELS_BOOKINGS" T0 [42104-232]
	at org.h2.message.DbException.getJdbcSQLException(DbException.java:514) ~[h2-2.3.232.jar:2.3.232]
	at org.h2.message.DbException.getJdbcSQLException(DbException.java:489) ~[h2-2.3.232.jar:2.3.232]
	at org.h2.message.DbException.get(DbException.java:223) ~[h2-2.3.232.jar:2.3.232]
	at org.h2.message.DbException.get(DbException.java:199) ~[h2-2.3.232.jar:2.3.232]
	at org.h2.command.Parser.getTableOrViewNotFoundDbException(Parser.java:7932) ~[h2-2.3.232.jar:2.3.232]
	at org.h2.command.Parser.getTableOrViewNotFoundDbException(Parser.java:7916) ~[h2-2.3.232.jar:2.3.232]
	at org.h2.command.Parser.readTableOrView(Parser.java:7895) ~[h2-2.3.232.jar:2.3.232]
	at org.h2.command.Parser.readTablePrimary(Parser.java:1769) ~[h2-2.3.232.jar:2.3.232]
	at org.h2.command.Parser.readTableReference(Parser.java:2249) ~[h2-2.3.232.jar:2.3.232]
	at org.h2.command.Parser.parseSelectFromPart(Parser.java:2702) ~[h2-2.3.232.jar:2.3.232]
	at org.h2.command.Parser.parseSelect(Parser.java:2810) ~[h2-2.3.232.jar:2.3.232]
	at org.h2.command.Parser.parseQueryPrimary(Parser.java:2692) ~[h2-2.3.232.jar:2.3.232]
	at org.h2.command.Parser.parseQueryTerm(Parser.java:2547) ~[h2-2.3.232.jar:2.3.232]
	at org.h2.command.Parser.parseQueryExpressionBody(Parser.java:2526) ~[h2-2.3.232.jar:2.3.232]
	at org.h2.command.Parser.parseQueryExpressionBodyAndEndOfQuery(Parser.java:2519) ~[h2-2.3.232.jar:2.3.232]
	at org.h2.command.Parser.parseQueryExpression(Parser.java:2512) ~[h2-2.3.232.jar:2.3.232]
	at org.h2.command.Parser.parseQuery(Parser.java:2479) ~[h2-2.3.232.jar:2.3.232]
	at org.h2.command.Parser.parsePrepared(Parser.java:610) ~[h2-2.3.232.jar:2.3.232]
	at org.h2.command.Parser.parse(Parser.java:581) ~[h2-2.3.232.jar:2.3.232]
	at org.h2.command.Parser.parse(Parser.java:556) ~[h2-2.3.232.jar:2.3.232]
	at org.h2.command.Parser.prepareCommand(Parser.java:484) ~[h2-2.3.232.jar:2.3.232]
	at org.h2.engine.SessionLocal.prepareLocal(SessionLocal.java:645) ~[h2-2.3.232.jar:2.3.232]
	at org.h2.engine.SessionLocal.prepareCommand(SessionLocal.java:561) ~[h2-2.3.232.jar:2.3.232]
	at org.h2.jdbc.JdbcConnection.prepareCommand(JdbcConnection.java:1164) ~[h2-2.3.232.jar:2.3.232]
	at org.h2.jdbc.JdbcPreparedStatement.<init>(JdbcPreparedStatement.java:93) ~[h2-2.3.232.jar:2.3.232]
	at org.h2.jdbc.JdbcConnection.prepareStatement(JdbcConnection.java:315) ~[h2-2.3.232.jar:2.3.232]
	at com.zaxxer.hikari.pool.ProxyConnection.prepareStatement(ProxyConnection.java:328) ~[HikariCP-6.3.3.jar:na]
	at com.zaxxer.hikari.pool.HikariProxyConnection.prepareStatement(HikariProxyConnection.java) ~[HikariCP-6.3.3.jar:na]
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[na:na]
	at java.base/java.lang.reflect.Method.invoke(Method.java:580) ~[na:na]
	at org.springframework.jdbc.datasource.TransactionAwareDataSourceProxy$TransactionAwareInvocationHandler.invoke(TransactionAwareDataSourceProxy.java:272) ~[spring-jdbc-6.2.11.jar:6.2.11]
	at jdk.proxy2/jdk.proxy2.$Proxy92.prepareStatement(Unknown Source) ~[na:na]
	at com.sap.cds.impl.JDBCClient.lambda$executeQuery$2(JDBCClient.java:236) ~[cds4j-runtime-4.4.1.jar:na]
	at com.sap.cds.impl.CqnLogger.sql(CqnLogger.java:104) ~[cds4j-core-4.4.1.jar:na]
	at com.sap.cds.impl.JDBCClient.executeQuery(JDBCClient.java:233) ~[cds4j-runtime-4.4.1.jar:na]
	at com.sap.cds.impl.JDBCClient.executeQuery(JDBCClient.java:206) ~[cds4j-runtime-4.4.1.jar:na]
	... 70 common frames omitted

```