### PR TITLE
Connect deployed XTravels with deployed XFlight

### DIFF
--- a/.github/workflows/cf.yaml
+++ b/.github/workflows/cf.yaml
@@ -1,7 +1,6 @@
 name: Cloud Foundry
 
 on:
-  pull_request:
   workflow_call:
     inputs:
       environment:

--- a/.github/workflows/cf.yaml
+++ b/.github/workflows/cf.yaml
@@ -1,6 +1,7 @@
 name: Cloud Foundry
 
 on:
+  pull_request:
   workflow_call:
     inputs:
       environment:

--- a/mta.yaml
+++ b/mta.yaml
@@ -19,6 +19,7 @@ modules:
       JBP_CONFIG_COMPONENTS: "jres: ['com.sap.xs.java.buildpack.jre.SAPMachineJRE']"
       JBP_CONFIG_SAP_MACHINE_JRE: '{ version: 21.+ }'
       AMS_DCL_ROOT: ams/dcl
+      XFLIGHTS_URL: https://cap-sandbox-capire-xflights-srv.cert.cfapps.eu12.hana.ondemand.com # TODO derive from GitHub environment
     build-parameters:
       builder: custom
       commands:

--- a/srv/src/main/resources/application.yaml
+++ b/srv/src/main/resources/application.yaml
@@ -14,6 +14,10 @@ management:
     db.enabled: true
 cds:
   drafts.enforce-readonly: true
+  security.mock.users:
+    admin:
+      roles:
+      - admin
   data-source.csv.paths:
   - "db/data/**"
   - "../db/data/**"
@@ -24,13 +28,18 @@ cds:
   - "../../node_modules/@capire/**"
 ---
 spring:
-  config.activate.on-profile: "!cloud"
-
+  config.activate.on-profile: "cloud"
 cds:
-  security.mock.users:
-    admin:
-      roles:
-        - admin
+  security.mock.enabled: false # required due to AMS lib
+  remote.services:
+    xflights:
+      type: hcql
+      model: sap.capire.flights.data
+      binding:
+        name: xtravels-ias
+        options:
+          url: ${XFLIGHTS_URL} # from mta.yaml
+          ias-dependency-name: xflights-data
 ---
 spring:
   config.activate.on-profile: hybrid

--- a/srv/src/main/resources/application.yaml
+++ b/srv/src/main/resources/application.yaml
@@ -38,8 +38,8 @@ cds:
       binding:
         name: xtravels-ias
         options:
-          url: ${XFLIGHTS_URL} # from mta.yaml
-          ias-dependency-name: xflights-data
+          url: ${XFLIGHTS_URL}/hcql # from mta.yaml
+          ias-dependency-name: DataConsumer
 ---
 spring:
   config.activate.on-profile: hybrid
@@ -51,6 +51,8 @@ cds:
       destination:
         properties:
           url: http://localhost:8081/hcql
+          User: consumer
+          Password:
 ---
 spring:
   config.activate.on-profile: default

--- a/srv/src/main/resources/application.yaml
+++ b/srv/src/main/resources/application.yaml
@@ -37,6 +37,7 @@ cds:
       model: sap.capire.flights.data
       binding:
         name: xtravels-ias
+        onBehalfOf: systemUser
         options:
           url: ${XFLIGHTS_URL}/hcql # from mta.yaml
           ias-dependency-name: DataConsumer

--- a/srv/src/main/resources/application.yaml
+++ b/srv/src/main/resources/application.yaml
@@ -35,12 +35,14 @@ cds:
     xflights:
       type: hcql
       model: sap.capire.flights.data
+      http:
+        suffix: /hcql
       binding:
         name: xtravels-ias
         onBehalfOf: systemUser
         options:
-          url: ${XFLIGHTS_URL}/hcql # from mta.yaml
-          ias-dependency-name: DataConsumer
+          url: ${XFLIGHTS_URL} # from mta.yaml
+          ias-dependency-name: data-consumer
 ---
 spring:
   config.activate.on-profile: hybrid

--- a/srv/src/main/resources/application.yaml
+++ b/srv/src/main/resources/application.yaml
@@ -28,7 +28,7 @@ cds:
   - "../../node_modules/@capire/**"
 ---
 spring:
-  config.activate.on-profile: "cloud"
+  config.activate.on-profile: cloud
 cds:
   security.mock.enabled: false # required due to AMS lib
   remote.services:
@@ -51,10 +51,12 @@ cds:
     xflights:
       type: hcql
       model: sap.capire.flights.data
+      http:
+        suffix: /hcql
       destination:
         properties:
-          url: http://localhost:8081/hcql
-          User: consumer
+          url: http://localhost:8081
+          User: internal
           Password:
 ---
 spring:


### PR DESCRIPTION
Requires: https://github.com/capire/xflights-java/pull/26
and requires App2App Dependency in shared IAS Tenant of XTravels and XFlights.